### PR TITLE
修改Dockerfile,使得构建出的docker镜像仅为17.4M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
-FROM golang:1.19-alpine
+FROM golang:1.19-alpine as builder
 
-ENV api_key=""
+RUN apk --no-cache add git && export GOPRIVATE=github.com/houko/wechatgpt && \
+    export GOPROXY=https://goproxy.cn,direct
 
-RUN export GOPRIVATE=github.com/houko/wechatgpt
+COPY . /root/build
 
-WORKDIR /app
-
-COPY . /app
+WORKDIR /root/build
 
 RUN go mod download && go build -o server main.go
 
-CMD ./server
+FROM alpine:latest as prod
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+COPY --from=0 /root/build/server .
+
+CMD ["./server"]

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -70,7 +69,6 @@ func GetWechatKeyword() *string {
 
 func GetTelegram() *string {
 	tg := getEnv("telegram")
-	fmt.Println(tg)
 	if tg != nil {
 		return tg
 	}


### PR DESCRIPTION
你好，我尝试修改Dockerfile使得编译出的镜像非常小巧，以下是前后两个Dockerfile编译出的容器镜像大小对比:
wechatgpt                            v1.0.0             5ff463b6fa00   8 minutes ago   17.4MB
xiaomoinfo/wechatgpt        latest             c7d65dd2d105   43 hours ago    1.14GB
希望采纳改进，谢谢
